### PR TITLE
Команда generate-pkg-zip. Исправил баг при создании архива zip из нескольких пакетов.

### DIFF
--- a/bpmcli/Program.cs
+++ b/bpmcli/Program.cs
@@ -801,7 +801,8 @@ namespace bpmcli
 					CompressionProject(options.Name, destinationPath);
 				} else {
 					var packages = GetPackages(options.Packages);
-					var destinationPath = string.IsNullOrEmpty(options.DestinationPath) ? $"Pkg{DateTime.Now}.zip" : options.DestinationPath;
+					string zipFileName = $"packages_{DateTime.Now.ToString("yy.MM.dd_hh.mm.ss")}.zip";
+					var destinationPath = string.IsNullOrEmpty(options.DestinationPath) ? zipFileName : options.DestinationPath;
 					CompressionProjects(options.Name, destinationPath, packages);
 				}
 				Console.WriteLine("Done");


### PR DESCRIPTION
Ошибка использования запрещенных символов при формировании имени файла, используя DateTime
![Screenshot_4](https://user-images.githubusercontent.com/6832799/56994546-11dec280-6ba8-11e9-8db0-a3c5d4468f80.png)

Плюс формирование файла аналогично выгрузки из конфигурации.